### PR TITLE
Feature expose min max

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ Lifecycle entry:
 
 `:sql/columns` supports restricting the select to only certain columns, e.g. `:sql/columns [:id :name]`.
 
-`sql/lower-bound` override `partition-key` selecting the min from the `sql/id` column.
+`:sql/lower-bound` overrides `partition-key` calculation of min from the `:sql/id` column.
 
-`sql/upper-bound` override `partition-key` selecting the max from the `sql/id` column.
+`:sql/upper-bound` overrides `partition-key` calculation of max from the `:sql/id` column.
 
 ##### read-rows
 
@@ -172,8 +172,8 @@ Lifecycle entry:
 |`:sql/table`            | `keyword` | The table to read/write from/to
 |`:sql/columns`          | `vector`  | Columns to select
 |`:sql/id`               | `keyword` | The name of a unique, monotonically increasing integer column
-|`:sql/lower-bound` | `integer` | Use instead of selecting the min value from the id column.
-|`:sql/upper-bound` | `integer` | Use instead of selecting the max value from the id column.
+|`:sql/lower-bound` | `integer` | Overrides the calculation of min value from the id column.
+|`:sql/upper-bound` | `integer` | Overrides the calculation of max value from the id column.
 |`:sql/rows-per-segment` | `integer` | the number of rows to compress into a single segment
 |`:sql/read-buffer`      | `integer` | The number of messages to buffer via core.async, default is `1000`
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Catalog entry:
  :sql/table :table-name
  :sql/id :column-to-split-by
  :sql/columns [:*]
+ ;; Optional
+ :sql/lower-bound selected-min
+ ;; Optional
+ :sql/upper-bound selected-max
  ;; 500 * 1000 = 50,000 rows
  ;; to be processed within :onyx/pending-timeout, 60s by default
  :sql/rows-per-segment 500
@@ -66,6 +70,10 @@ Lifecycle entry:
 ```
 
 `:sql/columns` supports restricting the select to only certain columns, e.g. `:sql/columns [:id :name]`.
+
+`sql/lower-bound` override `partition-key` selecting the min from the `sql/id` column.
+
+`sql/upper-bound` override `partition-key` selecting the max from the `sql/id` column.
 
 ##### read-rows
 
@@ -164,7 +172,9 @@ Lifecycle entry:
 |`:sql/table`            | `keyword` | The table to read/write from/to
 |`:sql/columns`          | `vector`  | Columns to select
 |`:sql/id`               | `keyword` | The name of a unique, monotonically increasing integer column
-|`:sql/rows-per-segment` | `integer` | The number of rows to compress into a single segment
+|`:sql/lower-bound` | `integer` | Use instead of selecting the min value from the id column.
+|`:sql/upper-bound` | `integer` | Use instead of selecting the max value from the id column.
+|`:sql/rows-per-segment` | `integer` | the number of rows to compress into a single segment
 |`:sql/read-buffer`      | `integer` | The number of messages to buffer via core.async, default is `1000`
 
 #### Contributing

--- a/src/onyx/sql/information_model.cljc
+++ b/src/onyx/sql/information_model.cljc
@@ -35,12 +35,12 @@
              :sql/lower-bound
              {:type :integer
               :optional? true
-              :doc "Use instead of selecting the min value from the id column."}
+              :doc "Overrides calculation of min value from the id column."}
 
              :sql/upper-bound
              {:type :integer
               :optional? true
-              :doc "Use instead of selecting the max value from the id column."}
+              :doc "Overrides calculation of max value from the id column."}
 
              :sql/rows-per-segment
              {:type :integer

--- a/src/onyx/sql/information_model.cljc
+++ b/src/onyx/sql/information_model.cljc
@@ -34,6 +34,8 @@
 
              :sql/rows-per-segment
              {:type :integer
+              :optional? true
+              :default 1000
               :doc "The number of rows to compress into a single segment."}
 
              :sql/read-buffer

--- a/src/onyx/sql/information_model.cljc
+++ b/src/onyx/sql/information_model.cljc
@@ -30,7 +30,17 @@
 
              :sql/id
              {:type :keyword
-              :doc "The name of a unique, monotonically increasing integer column."}
+              :doc "the name of a unique, monotonically increasing integer column."}
+
+             :sql/lower-bound
+             {:type :integer
+              :optional? true
+              :doc "Use instead of selecting the min value from the id column."}
+
+             :sql/upper-bound
+             {:type :integer
+              :optional? true
+              :doc "Use instead of selecting the max value from the id column."}
 
              :sql/rows-per-segment
              {:type :integer
@@ -155,6 +165,8 @@
      :sql/password
      :sql/table
      :sql/id
+     :sql/lower-bound
+     :sql/upper-bound
      :sql/rows-per-segment
      :sql/read-buffer]
 

--- a/src/onyx/tasks/sql.clj
+++ b/src/onyx/tasks/sql.clj
@@ -6,8 +6,8 @@
   {:sql/id s/Keyword
    (s/optional-key :sql/columns) [s/Keyword]
    (s/optional-key :sql/rows-per-segment) s/Num
-   (s/optional-key :sql/lower-bound) s/Num
-   (s/optional-key :sql/upper-bound) s/Num
+   (s/optional-key :sql/lower-bound) (s/cond-pre s/Uuid s/Num)
+   (s/optional-key :sql/upper-bound) (s/cond-pre s/Uuid s/Num)
    (s/optional-key :sql/read-buffer) s/Num
    :sql/classname s/Str
    :sql/subprotocol s/Str

--- a/src/onyx/tasks/sql.clj
+++ b/src/onyx/tasks/sql.clj
@@ -6,6 +6,8 @@
   {:sql/id s/Keyword
    (s/optional-key :sql/columns) [s/Keyword]
    (s/optional-key :sql/rows-per-segment) s/Num
+   (s/optional-key :sql/lower-bound) s/Num
+   (s/optional-key :sql/upper-bound) s/Num
    (s/optional-key :sql/read-buffer) s/Num
    :sql/classname s/Str
    :sql/subprotocol s/Str


### PR DESCRIPTION
Implemented exposing selected min, max as sql/lower-bound and sql/upper-bound. 
The values are merged into the event map, so that they are accessible from the lifecycles.

cheers 