### PR TITLE
Batch multi-row inserts in a single statement

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,3 @@
-
 (defproject org.onyxplatform/onyx-sql "0.10.0-beta14"
   :description "Onyx plugin for JDBC-backed SQL databases"
   :url "https://github.com/onyx-platform/onyx-sql"
@@ -13,7 +12,7 @@
                              :password :env
                              :sign-releases false}}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/java.jdbc "0.3.3"]
+                 [org.clojure/java.jdbc "0.7.0-alpha3"]
                  ^{:voom {:repo "git@github.com:onyx-platform/onyx.git" :branch "master"}}
                  [org.onyxplatform/onyx "0.10.0-beta14"]
                  [java-jdbc/dsl "0.1.3"]

--- a/src/onyx/plugin/sql.clj
+++ b/src/onyx/plugin/sql.clj
@@ -157,8 +157,7 @@
     (doseq [msg (mapcat :leaves (:tree results))]
       (jdbc/with-db-transaction
         [conn pool]
-        (doseq [row (:rows msg)]
-          (jdbc/insert! conn table row))))
+        (jdbc/insert-multi! conn table (:rows msg))))
     true))
 
 (defn write-rows [pipeline-data]


### PR DESCRIPTION
I've upgraded the JDBC driver to make use of the new function `insert-multi!`. This should bring significant performance improvements to people that batch multiple rows using e.g. window triggers.