### PR TITLE
Cleans up lifecycle calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,6 @@ Catalog entry:
  :onyx/doc "Partitions a range of primary keys into subranges"}
 ```
 
-Lifecycle entry:
-
-```clojure
-{:lifecycle/task :partition-keys
- :lifecycle/calls :onyx.plugin.sql/partition-keys-calls}
-```
-
 `:sql/columns` supports restricting the select to only certain columns, e.g. `:sql/columns [:id :name]`.
 
 `:sql/lower-bound` overrides `partition-key` calculation of min from the `:sql/id` column.
@@ -95,13 +88,6 @@ Catalog entry:
  :sql/table :table-name
  :sql/id :column-to-split-by
  :onyx/doc "Reads rows of a SQL table bounded by a key range"}
-```
-
-Lifecycle entry:
-
-```clojure
-{:lifecycle/task :read-rows
- :lifecycle/calls :onyx.plugin.sql/read-rows-calls}
 ```
 
 ##### write-rows
@@ -160,13 +146,6 @@ Catalog entry:
  :onyx/doc "Upserts segments from the :rows keys to the SQL database"}
 ```
 
-Lifecycle entry:
-
-```clojure
-{:lifecycle/task :upsert-rows
- :lifecycle/calls :onyx.plugin.sql/upsert-rows-calls}
-```
-
 #### Attributes
 
 |key                     | type      | description
@@ -190,8 +169,8 @@ Pull requests into the master branch are welcomed.
 
 Running the tests can be easily performed by starting a mysql and postgres container with docker:
 ```
- docker run -e MYSQL_ROOT_PASSWORD="password" -p 3306:3306 -d mysql:latest
- docker run -e POSTGRES_PASSWORD=password -e POSTGRES_USER=postgresql -e POSTGRES_DB=onyx_input_test -p 5432:5432 library/postgres
+ docker run -e MYSQL_ROOT_PASSWORD="password" -e MYSQL_DATABASE="onyx_input_test" -p 3306:3306 -d mysql:latest
+ docker run -e POSTGRES_PASSWORD=password -e POSTGRES_USER=postgresql -e POSTGRES_DB=onyx_input_test -p 5432:5432 -d library/postgres
  ```
 
 #### License

--- a/src/onyx/plugin/sql.clj
+++ b/src/onyx/plugin/sql.clj
@@ -141,6 +141,7 @@
     this)
 
   (stop [this event]
+    (.close (:datasource pool))
     this)
 
   p/BarrierSynchronization
@@ -189,6 +190,7 @@
     this)
 
   (stop [this event]
+    (.close (:datasource pool))
     this)
 
   p/BarrierSynchronization
@@ -225,33 +227,3 @@
         table (:sql/table task-map)
         pool (task->pool task-map)]
     (->SqlUpserter pool table)))
-
-(defn inject-write-rows
-  [event lifecycle]
-  {})
-
-(defn close-write-rows
-  [event lifecycle]
-  {})
-
-(defn inject-upsert-rows
-  [event lifecycle]
-  {})
-
-(defn close-update-rows
-  [event lifecycle]
-  {})
-
-(def partition-keys-calls
-  {})
-
-(def partition-uuid-calls
-  {})
-
-(def write-rows-calls
-  {:lifecycle/before-task-start inject-write-rows
-   :lifecycle/after-task-stop close-write-rows})
-
-(def upsert-rows-calls
-  {:lifecycle/before-task-start inject-upsert-rows
-   :lifecycle/after-task-stop close-update-rows})

--- a/src/onyx/sql/information_model.cljc
+++ b/src/onyx/sql/information_model.cljc
@@ -166,23 +166,19 @@
    :lifecycles-entry
    {:onyx.plugin.sql/partition-keys
     {:model
-     [{:task.lifecycle/name :partition-keys
-       :lifecycle/calls :onyx.plugin.sql/partition-keys-calls}]}
+     []}
 
     :onyx.plugin.sql/read-rows
     {:model
-     [{:task.lifecycle/name :read-rows
-       :lifecycle/calls :onyx.plugin.sql/read-rows-calls}]}
+     []}
 
     :onyx.plugin.sql/write-rows
     {:model
-     [{:task.lifecycle/name :write-rows
-       :lifecycle/calls :onyx.plugin.sql/write-rows-calls}]}
+     []}
 
     :onyx.plugin.sql/upsert-rows
     {:model
-     [{:task.lifecycle/name :upsert-rows
-       :lifecycle/calls :onyx.plugin.sql/upsert-rows-calls}]}}
+     []}}
 
    :display-order
    {:onyx.plugin.sql/partition-keys

--- a/src/onyx/tasks/sql.clj
+++ b/src/onyx/tasks/sql.clj
@@ -28,9 +28,7 @@
                              :sql/rows-per-segment 500
                              :sql/read-buffer 1000
                              :onyx/doc "Partitions a range of primary keys into subranges"}
-                            opts)
-           :lifecycles [{:lifecycle/task task-name
-                         :lifecycle/calls :onyx.plugin.sql/partition-keys-calls}]}
+                            opts)}
     :schema {:task-map SqlPartitionKeysTaskMap}})
   ([task-name :- s/Keyword
     classname :- s/Str
@@ -61,9 +59,7 @@
                              :sql/columns [:*]
                              :sql/rows-per-segment 500
                              :onyx/doc "Partitions a range of primary keys into subranges"}
-                            opts)
-           :lifecycles [{:lifecycle/task task-name
-                         :lifecycle/calls :onyx.plugin.sql/partition-uuid-calls}]}
+                            opts)}
     :schema {:task-map SqlPartitionKeysTaskMap}})
   ([task-name :- s/Keyword
     classname :- s/Str
@@ -106,9 +102,7 @@
                              :onyx/fn :onyx.plugin.sql/read-rows
                              :onyx/type :function
                              :onyx/doc "Reads rows of a SQL table bounded by a key range"}
-                            opts)
-           :lifecycles [{:lifecycle/task task-name
-                         :lifecycle/calls :onyx.plugin.sql/read-rows-calls}]}
+                            opts)}
     :schema {:task-map SqlReaderTaskMap}})
   ([task-name :- s/Keyword
     classname :- s/Str

--- a/test/onyx/plugin/output_copy_test.clj
+++ b/test/onyx/plugin/output_copy_test.clj
@@ -48,8 +48,6 @@
                              :onyx/type :function
                              :onyx/batch-size batch-size
                              :onyx/doc "Transforms a segment to prepare for SQL persistence"}]
-                  :lifecycles [{:lifecycle/task :out
-                                :lifecycle/calls :onyx.plugin.sql/write-rows-calls}]
                   :windows []
                   :triggers []
                   :flow-conditions []

--- a/test/onyx/plugin/output_test.clj
+++ b/test/onyx/plugin/output_test.clj
@@ -46,8 +46,6 @@
                              :onyx/type :function
                              :onyx/batch-size batch-size
                              :onyx/doc "Transforms a segment to prepare for SQL persistence"}]
-                  :lifecycles [{:lifecycle/task :out
-                                :lifecycle/calls :onyx.plugin.sql/write-rows-calls}]
                   :windows []
                   :triggers []
                   :flow-conditions []

--- a/test/onyx/plugin/output_update_test.clj
+++ b/test/onyx/plugin/output_update_test.clj
@@ -47,8 +47,6 @@
                              :onyx/type :function
                              :onyx/batch-size 1000
                              :onyx/doc "Transforms a segment to prepare for SQL persistence"}]
-                  :lifecycles [{:lifecycle/task :out
-                                :lifecycle/calls :onyx.plugin.sql/upsert-rows-calls}]
                   :windows []
                   :triggers []
                   :flow-conditions []


### PR DESCRIPTION
This PR cleans up all the lifecycle calls from code, fest and documentation. Furthermore, the upserter and writer tasks now close the connection appropriately at task stop.

Fixes #29 