### PR TITLE
BUGFIX: Getting subprotocol out of JDBC connection object

### DIFF
--- a/src/onyx/plugin/pgsql.clj
+++ b/src/onyx/plugin/pgsql.clj
@@ -80,4 +80,4 @@
   (hsql/format {:insert-into table
                 :values [(merge where row)]
                 :upsert {:on-conflict (keys where)
-                :do-update-set (keys row)}}))
+                         :do-update-set (keys row)}}))

--- a/src/onyx/plugin/sql.clj
+++ b/src/onyx/plugin/sql.clj
@@ -186,7 +186,7 @@
     (->SqlWriter pool insert-fn)))
 
 (defrecord SqlUpserter [pool table]
-    p/Plugin
+  p/Plugin
   (start [this event]
     this)
 
@@ -220,9 +220,9 @@
       (jdbc/with-db-transaction
         [conn pool]
         (doseq [row (:rows msg)]
-          (case (:subprotocol conn)
-            "postgresql" (jdbc/execute! conn (pgsql/upsert table row (:where msg)))
-            "mysql" (jdbc/execute! conn (mysql/upsert table row (:where msg)))
+          (condp #(str/starts-with? %2 %1) (.getJdbcUrl (:datasource conn))
+            "jdbc:postgresql" (jdbc/execute! conn (pgsql/upsert table row (:where msg)))
+            "jdbc:mysql" (jdbc/execute! conn (mysql/upsert table row (:where msg)))
             (jdbc/update! conn table row (sql-dsl/where (:where msg)))))))
     true))
 


### PR DESCRIPTION
Unfortunately, I realized I made a mistake in my previous code review that I just caught now.

My apologies for not catching it during earlier tests.